### PR TITLE
fix: Docker image gives error on Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ docker-run:
 		-e USER_ID=$(shell id -u) \
 		-e GROUP_ID=$(shell id -g) \
 		-e USER_NAME=$(shell id -un) \
+                --platform linux/amd64 \
 		--workdir /kubecon-na24-workshop-base \
 		--rm \
 		$(DOCKER_IMAGE)


### PR DESCRIPTION
The image provided requires forcing platform to be x64.

Not sure if something is odd about my Mac setup for it not to fallback when Rosetta is enabled. 