### PR TITLE
Add platform to allow this to work on arm based machines

### DIFF
--- a/demos/demo2/encrypt-container-image.sh
+++ b/demos/demo2/encrypt-container-image.sh
@@ -18,10 +18,10 @@ fi
 
 # Ensure we pull the images that are needed to perfom the encryption
 info "Pulling source image: ${SOURCE_IMAGE} ..."
-docker pull "${SOURCE_IMAGE}"
+docker pull --platform linux/amd64 "${SOURCE_IMAGE}"
 
 info "Pulling container image encryptor application: ${COCO_KEY_PROVIDER} ..."
-docker pull "${COCO_KEY_PROVIDER}"
+docker pull --platform linux/amd64 "${COCO_KEY_PROVIDER}"
 
 # If the encryption key file does not exists, then create it
 if [ ! -f "${ENCRYPTION_KEY_FILE}" ]; then


### PR DESCRIPTION
Script used to encrypt images does not work on Silicon macs when running within docker (that is already running as amd)